### PR TITLE
🔖 feat(loading_state_handler): Deprecate state properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,3 +118,7 @@
 - **Added**: typedefs for `onLoading`, `onError`, and `onData` callbacks in `StateHandlerWidget`.
 - **Added**: typedefs for `defaultOnLoading`, `defaultOnError`, and `defaultOnData` callbacks in `StateHandlerWidget`.
 - **Updated**: Readme to use the latest version of `loading_state_handler`.
+
+## 1.4.0
+
+- **Breaking Change**: Marked `loading`, `error`, `data`, and `empty` as `deprecated`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: loading_state_handler
 description: "The StateHandlerWidget manages different UI states—loading, error, empty, and normal—allowing you to customize the displayed widgets for each state."
-version: 1.3.3
+version: 1.4.0
 homepage: https://github.com/Mahmoud-Saeed-Mahmoud/loading_state_handler
 
 environment:


### PR DESCRIPTION
Deprecate the `loading`, `error`, `data`, and `empty` properties in the
`StateHandlerWidget` class. This change is a breaking change and will
require users to update their code to use the new callback-based
approach introduced in version 1.3.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Deprecated states `loading`, `error`, `data`, and `empty` in `StateHandlerWidget`

- **Documentation**
	- Updated README to reflect version 1.4.0

- **Version Update**
	- Bumped package version from 1.3.3 to 1.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->