### PR TITLE
🔥 feat(StateHandlerWidget): deprecate state properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,4 +121,19 @@
 
 ## 1.4.0
 
-- **Breaking Change**: Marked `loading`, `error`, `data`, and `empty` as `deprecated`.
+### Breaking Changes
+ **Deprecated**: The following state properties in `StateHandlerWidget` are now marked as deprecated:
+  * `loading`
+  * `error`
+  * `data`
+  * `empty`
+
+### Migration Guide
+* Users should transition to the callback-based approach introduced in v1.3.3
+
+* Replace state properties with their corresponding callbacks:
+        
+    * Use `currentState` instead of `loading`
+    * Use `currentState` instead of `error`
+    * Use `currentState` instead of `data`
+    * Use `currentState` instead of `empty`


### PR DESCRIPTION
The state properties `loading`, `error`, `data`, and `empty` in the
`StateHandlerWidget` have been marked as deprecated. Users should
transition to the callback-based approach introduced in v1.3.3. This
change aims to simplify the API and encourage a more flexible and
extensible state management strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Deprecated state properties in `StateHandlerWidget`
	- Added migration guide for transitioning to callback-based state handling

- **Documentation**
	- Updated changelog with detailed migration instructions for version 1.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->