### PR TITLE
✨ feat(deps): add false_secrets config to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,9 @@ dependencies:
 dev_dependencies:
   flutter_lints: ^5.0.0
 
+false_secrets: 
+  - .json
+
   # For information on the generic Dart part of this file, see the
   # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
Adds a new `false_secrets` configuration to the `pubspec.yaml` file.
This allows the project to specify a list of JSON files that should
be considered as "false secrets" and not included in the final
application bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration with a new section in `pubspec.yaml`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->