### PR TITLE
✨ feat(deps): update false_secrets pattern in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
 
 false_secrets: 
-  - .json
+  - '*.json'
 
   # For information on the generic Dart part of this file, see the
   # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Modify the `false_secrets` pattern in the `pubspec.yaml` file to
include all JSON files instead of a single `.json` file. This
change ensures that the project's build process ignores all
JSON files, which is a common practice for handling sensitive
data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated false secrets configuration to use wildcard pattern for JSON files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->