### PR TITLE
✨ feat(loading_state_handler_widget): Improve retry message formatting

### DIFF
--- a/lib/src/loading_state_handler_widget.dart
+++ b/lib/src/loading_state_handler_widget.dart
@@ -670,7 +670,7 @@ class _LoadingStateHandlerWidgetState extends State<LoadingStateHandlerWidget> {
         if (_remainingCooldown > 0)
           Text(
             '${widget.retryMessage ?? LoadingStateHandlerWidget._defaultRetryMessage}'
-                .replaceAll(
+                .replaceFirst(
               RegExp(r"%_"),
               _remainingCooldown.toString(),
             ),


### PR DESCRIPTION
Replaces the first occurrence of "%_" in the retry message with the
remaining cooldown time, instead of replacing all occurrences. This
ensures the message is displayed correctly when the cooldown time is
greater than 10 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated retry message formatting to replace only the first occurrence of the placeholder, improving message display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->