### PR TITLE
🔒 feat(sdk): Restrict Dart SDK version to 3.6.1

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,4 +75,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.5.4 <4.0.0"
+  dart: ">=3.5.4 <=3.6.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - error
 
 environment:
-  sdk: ">=3.0.0 <=4.0.0"
+  sdk: ">=3.0.0 <=3.6.1"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Restricts the Dart SDK version to `>=3.0.0 <=3.6.1` in the `pubspec.yaml` file
and the `example/pubspec.lock` file. This change ensures that the project
is compatible with Dart version 3.6.1 and below, providing a more
controlled and stable development environment.