### PR TITLE
update-dart-sdk-version

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,4 +75,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.5.4 <=3.6.1"
+  dart: ">=3.4.0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.2.0
 
 environment:
-  sdk: ^3.5.4
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   loading_state_handler:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
   - error
 
 environment:
-  sdk: ">=3.0.0 <=3.6.1"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Here is the pull request description:

This pull request updates the Dart SDK version range in the `pubspec.yaml` and `pubspec.lock` files to support a wider range of Dart versions, from `>=3.0.0 <4.0.0` and `>=3.4.0 <4.0.0` respectively. This ensures the project can be built and run with the latest stable Dart releases.

The key changes are:

- Chore: Update Dart SDK version range in `pubspec.yaml` and `pubspec.lock` files
- Feature: Expand Dart SDK version range in `pubspec.yaml` to support newer versions of Dart up to, but not including, version 4.0.0

This change will help keep the project up-to-date with the latest Dart releases and ensure compatibility with the latest language features and improvements.